### PR TITLE
Fix touchplate coord mirroring

### DIFF
--- a/inkplate-1.yaml
+++ b/inkplate-1.yaml
@@ -74,8 +74,8 @@ touchscreen:
     display: inkplate_display
     # Following is specific to 6PLUS rotated display.
     transform:
-      mirror_x: false
-      mirror_y: true
+      mirror_x: true
+      mirror_y: false
       swap_xy: true
     rts_pin:
       mcp23xxx: mcp23017_hub


### PR DESCRIPTION
Recent update to ESPHome changed how touchplate coordinates were mapped when the screen is rotated, this corrects it so the touches map to the correct buttons on the 6PLUS.